### PR TITLE
Update page content label

### DIFF
--- a/linkit/types/page.py
+++ b/linkit/types/page.py
@@ -48,6 +48,7 @@ class PageType(LinkType):
     def label(self):
         real_value = self.real_value()
         if real_value:
-            return real_value.get_content_obj()
+            page_content = real_value.get_content_obj()
+            return page_content.title
 
         return False


### PR DESCRIPTION
The `__str__` method of the PageContent:

<img width="489" height="69" alt="image" src="https://github.com/user-attachments/assets/2a5aefdf-c50e-478c-b70a-6db3cd388276" />

contains the language.

It would be better if we go directly to the tilte for the page label