### PR TITLE
Remove pkg_resources because its deprecated and not really needed

### DIFF
--- a/linkit/types/page.py
+++ b/linkit/types/page.py
@@ -4,7 +4,6 @@ from typing import Optional
 from cms.forms.fields import PageSelectFormField
 from cms.models import Page
 from django.utils.translation import gettext_lazy as _
-from pkg_resources import parse_version
 
 from linkit.types.contracts import LinkType, TypeForm
 
@@ -19,7 +18,7 @@ class PageTypeForm(TypeForm):
         """ Set the queryset and label dynamically based on the properties defined on the link type. """
         super().__init__(*args, **kwargs)
         self.fields['page'].to_field_name = self.link_type.id
-        if cms_version and parse_version(cms_version) >= parse_version("4.0.0"):
+        if cms_version and cms_version >= "4.0.0":
             queryset = Page.objects.all()
         else:
             queryset = Page.objects.drafts()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Django==1.11.29
-django-admin==1.3.2
-django-cms==3.5.3
-django-filer==1.4.4
+Django==5.2
+django-cms==5.0
+django-filer==3.3


### PR DESCRIPTION
I saw this in pytest warnings:

<img width="1055" height="45" alt="image" src="https://github.com/user-attachments/assets/b7914576-dada-4512-9c9b-a134f11e8630" />

And the deprecation is also mentioned here:
<img width="904" height="159" alt="image" src="https://github.com/user-attachments/assets/9d10799f-366c-4448-ac10-f9fa4afe5999" />
https://setuptools.pypa.io/en/latest/pkg_resources.html

It also seems like its not really needed. because importlib.metadata version() already returns the string:

<img width="671" height="86" alt="image" src="https://github.com/user-attachments/assets/862b2272-70b7-4c2f-9c88-636838a829d9" />
